### PR TITLE
Homepage header link is broken (and misleading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+`jquery-textcomplete` is no longer maintained. Please use [yuku-t/textcomplete](https://github.com/yuku-t/textcomplete) instead.


### PR DESCRIPTION
(Sorry I sent this PR because the issue board is closed. 🙇 )

Want to point out that the current repo homepage header link is broken and kinda misleading.

![yuku_jquery-textcomplete__deprecated__use_yuku-t_textcomplete](https://user-images.githubusercontent.com/184520/44784017-2573fc80-abc7-11e8-9d84-a22aa1edc6a0.png)

It reads as if the link in the screenshot above is the one recommended, but it's actually not. After clicking it, the page couldn't be loaded.. making us clueless.

![image](https://user-images.githubusercontent.com/184520/44784191-bea31300-abc7-11e8-8662-8b437d5262f0.png)

It happened to me several times, and to my friends whoever I asked... 😓 

I think either update or remove the link, optionally still keep a README with the correct link is better. I know it's not maintained anymore, but wish we can still do better to leave a proper saryonara message 🙏 